### PR TITLE
Add ESM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /node_modules
 .tern-*
+
+*.iml
+*.mjs

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+node_modules/
+
+rollup.config.js
+
+*.iml

--- a/package.json
+++ b/package.json
@@ -3,15 +3,28 @@
   "version": "1.0.0",
   "description": "Persistent ordered mapping from strings",
   "main": "index.js",
+  "module": "index.mjs",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/marijnh/orderedmap.git"
   },
-  "keywords": ["persistent", "map"],
+  "keywords": [
+    "persistent",
+    "map"
+  ],
   "author": "Marijn Haverbeke <marijnh@gmail.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/marijnh/orderedmap/issues"
   },
-  "homepage": "https://github.com/marijnh/orderedmap#readme"
+  "homepage": "https://github.com/marijnh/orderedmap#readme",
+  "scripts": {
+    "build": "rollup -c",
+    "watch": "rollup -c -w",
+    "prepare": "npm run build"
+  },
+  "devDependencies": {
+    "rollup": "^1.26.3",
+    "rollup-plugin-commonjs": "^10.1.0"
+  }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,10 @@
+import commonjs from 'rollup-plugin-commonjs';
+
+export default {
+    input: 'index.js',
+    output: {
+        file: 'index.mjs',
+        format: 'esm'
+    },
+    plugins: [commonjs()]
+};


### PR DESCRIPTION
Here is the first PR we discussed. 

The idea is to not touch the existing code but to generate the ESM version using rollup. The generated ESM version is included in the NPM package before releasing it. The `module` field is added to _package.json_ for automatic detection by common tools.