### PR TITLE
Publish Typescript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "main": "index.js",
   "module": "index.es.js",
   "types": "types/index.d.ts",
+  "files": [
+    "types",
+    "index.es.js"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/marijnh/orderedmap.git"


### PR DESCRIPTION
Typescript types were added in #6, but they're not actually published.

<img width="162" alt="Screenshot 2022-02-17 at 18 07 43" src="https://user-images.githubusercontent.com/2003804/154543787-2cb25428-36d4-437e-9692-a86b5c883297.png">
