### PR TITLE
chore: fix TypeScript types on constructor and `get` method

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 declare class OrderedMap<T = any> {
-  constructor(content: T[])
+  constructor(content: Array<string | T>)
 
-  get(key: string): T
+  get(key: string): T | undefined
 
   update(key: string, value: T, newKey?: string): OrderedMap<T>
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
 declare class OrderedMap<T = any> {
-  constructor(content: Array<string | T>)
+  private constructor(content: Array<string | T>)
 
   get(key: string): T | undefined
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,4 +28,4 @@ declare class OrderedMap<T = any> {
 
 type MapLike<T = any> = Record<string, T> | OrderedMap<T>
 
-export default OrderedMap
+export = OrderedMap


### PR DESCRIPTION
Apologies, I should have picked these type issues up in my pull request yesterday.

* Allow for the constructor to accept strings (keys) and generic type `T` values (otherwise it won't accept string keys)
* Make it explicit that the `get` method could return undefined.