### PR TITLE
feat: add toObject method

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,6 +108,14 @@ OrderedMap.prototype = {
     return result
   },
 
+  // :: () → Object
+  // Turn ordered map into a plain object.
+  toObject: function() {
+    var result = {}
+    this.forEach(function(key, value) { result[key] = value })
+    return result
+  },
+
   // :: number
   // The amount of keys in this map.
   get size() {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,6 +21,8 @@ declare class OrderedMap<T = any> {
 
   subtract(map: MapLike<T>): OrderedMap<T>
 
+  toObject<T extends Record<string, any> = Record<string, any>>(): T;
+
   readonly size: number
 
   static from<T>(map: MapLike<T>): OrderedMap<T>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,7 +21,7 @@ declare class OrderedMap<T = any> {
 
   subtract(map: MapLike<T>): OrderedMap<T>
 
-  toObject<T extends Record<string, any> = Record<string, any>>(): T;
+  toObject(): Record<string, T>;
 
   readonly size: number
 


### PR DESCRIPTION
Add a `toObject` method for `OrderedMap`. This feature makes it possible to do something like:

```typescript
Object
  .entreis(orderedMap.toObject())
  .map(([key, value]) => {
    // ...
  });
```