### PR TITLE
fix: align changes with dist for d.ts

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -21,6 +21,8 @@ declare class OrderedMap<T = any> {
 
   subtract(map: MapLike<T>): OrderedMap<T>
 
+  toObject(): Record<string, T>;
+
   readonly size: number
 
   static from<T>(map: MapLike<T>): OrderedMap<T>


### PR DESCRIPTION
It would be greate if we don't need to align changes of type files manually.