### PR TITLE
Add support for System.iterator for-loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /dist/index.cjs
 .tern-*
 *.iml
+.idea
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -67,3 +67,6 @@ Return an object that has the same key/value pairs as the `map`.
 
 **`size`**`: number`  
 The amount of keys in this map.
+
+**`[System.iterator]()`**
+Return a for-loop iterator to allow calling `for(const [key,value] of orderedMap) { ... }`

--- a/__tests__/ordered-map.spec.js
+++ b/__tests__/ordered-map.spec.js
@@ -1,0 +1,28 @@
+const OrderedMap = require('../dist/index.cjs');
+
+describe("OrderedMap", () => {
+    test("System.iterator support", () => {
+        const testObject = OrderedMap.from({
+            a: 1,
+            b: 2,
+            c: 3
+        });
+
+        let index = 0;
+        for(const [key, value] of testObject) {
+            if (index === 0) {
+                expect(key).toEqual('a');
+                expect(value).toEqual(1);
+            } else if (index === 1) {
+                expect(key).toEqual('b');
+                expect(value).toEqual(2);
+            } else if (index === 2) {
+                expect(key).toEqual('c');
+                expect(value).toEqual(3);
+            } else {
+                throw new Error('should have not get here')
+            }
+            index++;
+        }
+    });
+});

--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ OrderedMap.prototype = {
     return this.content.length >> 1
   },
 
-  // :: System.iterator() → [...[key, value]]
+  // :: [System.iterator]() → [...[key, value]]
   // provides a standard Symbol.iterator for-loop factory iterator over the content of the OrderedMap
   // to allow iterator over it with a for (const item of items) {}.
   [Symbol.iterator]() {

--- a/index.js
+++ b/index.js
@@ -120,6 +120,26 @@ OrderedMap.prototype = {
   // The amount of keys in this map.
   get size() {
     return this.content.length >> 1
+  },
+
+  // :: System.iterator() → [...[key, value]]
+  // provides a standard Symbol.iterator for-loop factory iterator over the content of the OrderedMap
+  // to allow iterator over it with a for (const item of items) {}.
+  [Symbol.iterator]() {
+    let index = 0;
+    const content = [...this.content];
+    const maxLength = content.length - 1;
+    return {
+      next() {
+        if (index < maxLength) {
+          // read the next pair of key/value and advance the index as we go
+          const value = [content[index++], content[index++]];
+          return { value, done: false };
+        } else {
+          return { done: true };
+        }
+      }
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -31,9 +31,11 @@
   "scripts": {
     "build": "rollup -c",
     "watch": "rollup -c -w",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "test": "jest"
   },
   "devDependencies": {
-    "rollup": "^1.26.3"
+    "rollup": "^1.26.3",
+    "jest": "^29.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orderedmap",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Persistent ordered mapping from strings",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
Allow using the standard JS for-loop over the content of an ordered map instance.

In addition to the original `.forEach` syntax of:
```javascript
myOrderedMap.forEach((key,value) => {
...
});
```

You can now also use it as:
```javascript
for( const [key, value] of myOrderedMap) {
...
}
```

NOTE: the motivation for this fix is that modern `eslinter` configuration (like the `unicorn` recommended rules) will auto-replace `.forEach()` with a `for() {}` loop. Without this addition to the `OrderedMap` implementation, the linter will break your code.