### PR TITLE
add a Map method

### DIFF
--- a/dist/index.d.cts
+++ b/dist/index.d.cts
@@ -23,6 +23,8 @@ declare class OrderedMap<T = any> {
 
   toObject(): Record<string, T>;
 
+  map(fn: (key: string, value: T) => [string, T]): OrderedMap<T>
+
   readonly size: number
 
   static from<T>(map: MapLike<T>): OrderedMap<T>

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -23,6 +23,8 @@ declare class OrderedMap<T = any> {
 
   toObject(): Record<string, T>;
 
+  map(fn: (key: string, value: T) => [string, T]): OrderedMap<T>
+
   readonly size: number
 
   static from<T>(map: MapLike<T>): OrderedMap<T>

--- a/index.js
+++ b/index.js
@@ -116,6 +116,15 @@ OrderedMap.prototype = {
     return result
   },
 
+  // :: ((key: string, value: any) → [string, any]) → OrderedMap
+  // Create a new map by calling the given function for each key/value
+  // pair in the map in order, and replacing with updated values.
+  map: function(f) {
+    var content = []
+    this.forEach(function(key, value) { content.push(...f(key, value)) })
+    return new OrderedMap(content)
+  },
+
   // :: number
   // The amount of keys in this map.
   get size() {


### PR DESCRIPTION
The current way to iterate through an OrderedMap and update multiple values at once while maintaining order is

```js
const map = OrderedMap
let copy = map
map.forEach((key, value) => {
  const [newValue, newKey] = f(key, value)
  copy = copy.update(key, newValue, newKey)
})
```

But because `update` creates a new `OrderedMap` for each key and internally uses `find` each time, it's a bit cumbersome to use. `map` fixes this by only creating the new `OrderedMap` at the end.

Alternatively, if the constructor for `OrderedMap` was made public by modifying the lib types, this code could just easily exist outside this lib. 

My specific use case is conditionally adding attrs to an existing ProseMirror schema nodes, which involves mapping and maintaining order.

Thanks!